### PR TITLE
Model refactor

### DIFF
--- a/Renderer/RenderData/Mesh.cs
+++ b/Renderer/RenderData/Mesh.cs
@@ -169,14 +169,7 @@ public class Mesh : IDisposable
 
 	public void Draw( SceneObject? sceneobject )
 	{
-		if ( sceneobject is not null && sceneobject.MaterialOverride is not null )
-		{
-			sceneobject.MaterialOverride.Use();
-		}
-		else
-		{
-			Material.Use();
-		}
+		Material.Use();
 
 		OpenTKMath.Matrix4 transform = OpenTKMath.Matrix4.Identity;
 		if ( sceneobject is not null )

--- a/Renderer/RenderData/Mesh.cs
+++ b/Renderer/RenderData/Mesh.cs
@@ -74,6 +74,84 @@ public class Mesh : IDisposable
 		SetupMesh( Material );
 	}
 
+	public void SetupRenderAttributes( Material mat )
+	{
+		// enable again in case we called this from outside of setupmesh
+		GL.BindVertexArray( vao );
+
+		// vertex positions
+		var vertexPositionLocation = mat.GetAttribLocation( "vPosition" );
+		if ( vertexPositionLocation >= 0 )
+		{
+			GL.EnableVertexAttribArray( vertexPositionLocation );
+			GL.VertexAttribPointer( vertexPositionLocation, 3, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), 0 );
+		}
+
+		// vertex normal
+		var vertexNormalLocation = mat.GetAttribLocation( "vNormal" );
+		if ( vertexNormalLocation >= 0 )
+		{
+			GL.EnableVertexAttribArray( vertexNormalLocation );
+			GL.VertexAttribPointer( vertexNormalLocation, 3, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "normal" ) );
+		}
+
+		// vertex tangent
+		var vertexTangentLocation = mat.GetAttribLocation( "vTangent" );
+		if ( vertexTangentLocation >= 0 )
+		{
+			GL.EnableVertexAttribArray( vertexTangentLocation );
+			GL.VertexAttribPointer( vertexTangentLocation, 3, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "tangent" ) );
+		}
+
+		// vertex bitangent
+		var vertexBitangentLocation = mat.GetAttribLocation( "vBitangent" );
+		if ( vertexBitangentLocation >= 0 )
+		{
+			GL.EnableVertexAttribArray( vertexBitangentLocation );
+			GL.VertexAttribPointer( vertexBitangentLocation, 3, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "bitangent" ) );
+		}
+
+		// uv0
+		var uv0Location = mat.GetAttribLocation( "vTexCoord0" );
+		if ( uv0Location >= 0 )
+		{
+			GL.EnableVertexAttribArray( uv0Location );
+			GL.VertexAttribPointer( uv0Location, 2, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "uv0" ) );
+		}
+
+		// uv1
+		var uv1Location = mat.GetAttribLocation( "vTexCoord1" );
+		if ( uv1Location >= 0 )
+		{
+			GL.EnableVertexAttribArray( uv1Location );
+			GL.VertexAttribPointer( uv1Location, 2, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "uv1" ) );
+		}
+
+		// uv2
+		var uv2Location = mat.GetAttribLocation( "vTexCoord2" );
+		if ( uv2Location >= 0 )
+		{
+			GL.EnableVertexAttribArray( uv2Location );
+			GL.VertexAttribPointer( uv2Location, 2, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "uv2" ) );
+		}
+
+		// uv3
+		var uv3Location = mat.GetAttribLocation( "vTexCoord3" );
+		if ( uv3Location >= 0 )
+		{
+			GL.EnableVertexAttribArray( uv3Location );
+			GL.VertexAttribPointer( uv3Location, 2, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "uv3" ) );
+		}
+
+		// vertex color
+		var vertexColorLocation = mat.GetAttribLocation( "vColor" );
+		if ( vertexColorLocation >= 0 )
+		{
+			GL.EnableVertexAttribArray( vertexColorLocation );
+			GL.VertexAttribPointer( vertexColorLocation, 3, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "color" ) );
+		}
+	}
+
 	public void SetupMesh( Material mat )
 	{
 		// use shader first to get attributes
@@ -87,77 +165,7 @@ public class Mesh : IDisposable
 		GLUtil.CreateVertexArray( "Mesh VAO", out vao );
 		GL.BindVertexArray( vao );
 
-		// vertex positions
-		var vertexPositionLocation = Material.GetAttribLocation( "vPosition" );
-		if ( vertexPositionLocation >= 0 )
-		{
-			GL.EnableVertexAttribArray( vertexPositionLocation );
-			GL.VertexAttribPointer( vertexPositionLocation, 3, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), 0 );
-		}
-
-		// vertex normal
-		var vertexNormalLocation = Material.GetAttribLocation( "vNormal" );
-		if ( vertexNormalLocation >= 0 )
-		{
-			GL.EnableVertexAttribArray( vertexNormalLocation );
-			GL.VertexAttribPointer( vertexNormalLocation, 3, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "normal" ) );
-		}
-
-		// vertex tangent
-		var vertexTangentLocation = Material.GetAttribLocation( "vTangent" );
-		if ( vertexTangentLocation >= 0 )
-		{
-			GL.EnableVertexAttribArray( vertexTangentLocation );
-			GL.VertexAttribPointer( vertexTangentLocation, 3, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "tangent" ) );
-		}
-
-		// vertex bitangent
-		var vertexBitangentLocation = Material.GetAttribLocation( "vBitangent" );
-		if ( vertexBitangentLocation >= 0 )
-		{
-			GL.EnableVertexAttribArray( vertexBitangentLocation );
-			GL.VertexAttribPointer( vertexBitangentLocation, 3, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "bitangent" ) );
-		}
-
-		// uv0
-		var uv0Location = Material.GetAttribLocation( "vTexCoord0" );
-		if ( uv0Location >= 0 )
-		{
-			GL.EnableVertexAttribArray( uv0Location );
-			GL.VertexAttribPointer( uv0Location, 2, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "uv0" ) );
-		}
-
-		// uv1
-		var uv1Location = Material.GetAttribLocation( "vTexCoord1" );
-		if ( uv1Location >= 0 )
-		{
-			GL.EnableVertexAttribArray( uv1Location );
-			GL.VertexAttribPointer( uv1Location, 2, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "uv1" ) );
-		}
-
-		// uv2
-		var uv2Location = Material.GetAttribLocation( "vTexCoord2" );
-		if ( uv2Location >= 0 )
-		{
-			GL.EnableVertexAttribArray( uv2Location );
-			GL.VertexAttribPointer( uv2Location, 2, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "uv2" ) );
-		}
-
-		// uv3
-		var uv3Location = Material.GetAttribLocation( "vTexCoord3" );
-		if ( uv3Location >= 0 )
-		{
-			GL.EnableVertexAttribArray( uv3Location );
-			GL.VertexAttribPointer( uv3Location, 2, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "uv3" ) );
-		}
-
-		// vertex color
-		var vertexColorLocation = Material.GetAttribLocation( "vColor" );
-		if ( vertexColorLocation >= 0 )
-		{
-			GL.EnableVertexAttribArray( vertexColorLocation );
-			GL.VertexAttribPointer( vertexColorLocation, 3, VertexAttribPointerType.Float, false, Marshal.SizeOf( typeof( Vertex ) ), Marshal.OffsetOf( typeof( Vertex ), "color" ) );
-		}
+		SetupRenderAttributes( mat );
 
 		// create, bind and populate ebo
 		GLUtil.CreateBuffer( "Mesh EBO", out ebo );

--- a/Renderer/RenderData/Model.cs
+++ b/Renderer/RenderData/Model.cs
@@ -66,8 +66,8 @@ public struct Model
 
 	private static BBox GenerateRenderBounds( Mesh[] meshes )
 	{
-		Vector3 mins = meshes[0].Vertices[0].position;
-		Vector3 maxs = meshes[0].Vertices[0].position;
+		Vector3 mins = default;
+		Vector3 maxs = default;
 
 		foreach ( var mesh in meshes )
 		{

--- a/Renderer/RenderData/Model.cs
+++ b/Renderer/RenderData/Model.cs
@@ -3,112 +3,39 @@ using System.Reflection;
 
 namespace Vanadium.Renderer.RenderData;
 
-public class Model : IDisposable
+public struct Model
 {
-	public Mesh[]? Meshes;
-
-	public bool IsError = false;
-
+	public Mesh[] Meshes;
+	public bool IsError => Name == Error;
+	private readonly string Name;
 	public static string Error => "models/primitives/error.fbx";
 	public static Model ErrorModel => Load( Error );
-
-	private static readonly Dictionary<string, Model> PrecachedModels = new();
-
+	private static readonly Dictionary<string, Model> _cache = new();
 	public BBox RenderBounds { get; private set; }
 
-	public void SetMaterialOverride( string path )
+	public Model( string name, Mesh[] meshes )
 	{
-		if ( IsError ) return;
-		SetMeshMaterials( Material.Load( path ) );
+		Name = name;
+		Meshes = meshes;
+		RenderBounds = GenerateRenderBounds( meshes );
 	}
 
-	public void SetMeshMaterials( Material mat )
+	public void SetMaterialOverride( string mat )
 	{
-		if ( Meshes is null ) return;
+		SetMaterialOverride( Material.Load( mat ) );
+	}
+
+	public void SetMaterialOverride( Material mat )
+	{
 		foreach ( var mesh in Meshes )
 		{
 			mesh.Material = mat;
 		}
 	}
 
-	public void SetupMeshes()
-	{
-		if ( Meshes is null ) return;
-		foreach ( var mesh in Meshes )
-		{
-			mesh.SetupMesh();
-		}
-	}
-
-	public void SetupMeshes( Material mat )
-	{
-		if ( Meshes is null ) return;
-		foreach ( var mesh in Meshes )
-		{
-			mesh.SetupMesh( mat );
-		}
-	}
-
 	public static void Precache( string path )
 	{
-		Load( path );
-	}
-
-	public void Dispose()
-	{
-		if ( Meshes is not null )
-		{
-			foreach ( var mesh in Meshes )
-			{
-				mesh.Dispose();
-			}
-		}
-		GC.SuppressFinalize( this );
-	}
-
-	public static Model Load( string path )
-	{
-		var oldpath = path;
-		path = $"resources/{path}";
-
-		if ( PrecachedModels.TryGetValue( path, out var mdl ) )
-		{
-			return mdl;
-		}
-
-		Log.Info( $"loading model: {path}" );
-		var fileName = Path.Combine( $"{Path.GetDirectoryName( Assembly.GetExecutingAssembly().Location )}", path );
-
-		AssimpContext importer = new();
-
-		Assimp.Scene? scene;
-		try
-		{
-			scene = importer.ImportFile( fileName, PostProcessPreset.TargetRealTimeMaximumQuality | PostProcessSteps.FlipUVs | PostProcessSteps.Triangulate | PostProcessSteps.CalculateTangentSpace );
-		}
-		catch ( FileNotFoundException ex )
-		{
-			Log.Info( $"ERROR IMPORTING MODEL {fileName} ({ex})" );
-			return ErrorModel;
-		}
-
-		if ( scene is null || scene.SceneFlags == SceneFlags.Incomplete || scene.RootNode is null )
-		{
-			Log.Info( "ASSIMP IMPORT ERROR" );
-			return ErrorModel;
-		}
-
-		Model model = new();
-		model.Meshes = new Mesh[scene.MeshCount];
-		model.ProcessNode( scene.RootNode, scene );
-		model.RenderBounds = model.GetRenderBounds();
-		PrecachedModels.Add( path, model );
-
-		if ( oldpath == Error )
-			model.IsError = true;
-
-		Log.Info( $"finished loading model: {path}" );
-		return model;
+		_ = Load( path );
 	}
 
 	public void Draw()
@@ -116,111 +43,33 @@ public class Model : IDisposable
 		Draw( null );
 	}
 
-	public void Draw( SceneObject? sceneobject )
+	public void Draw( SceneObject? obj )
 	{
-		if ( Meshes is null ) return;
 		foreach ( var mesh in Meshes )
 		{
-			mesh.Draw( sceneobject );
+			mesh.Draw( obj );
 		}
 	}
 
-	private void ProcessNode( Node node, Assimp.Scene scene )
+	public static Model Load( string path )
 	{
-		if ( Meshes is null ) return;
-		foreach ( int index in node.MeshIndices )
+		if ( _cache.TryGetValue( path, out Model cachedmodel ) )
 		{
-			Assimp.Mesh mesh = scene.Meshes[index];
-			Meshes[index] = ProcessMesh( mesh, scene );
+			return cachedmodel;
 		}
-		for ( int i = 0; i < node.ChildCount; i++ )
-		{
-			ProcessNode( node.Children[i], scene );
-		}
+
+		var builder = new ModelBuilder().FromFile( path );
+		var model = builder.Build();
+		_cache.Add( path, model );
+		return model;
 	}
 
-	private static Mesh ProcessMesh( Assimp.Mesh mesh, Assimp.Scene scene )
+	private static BBox GenerateRenderBounds( Mesh[] meshes )
 	{
-		Mesh.Vertex[] vertices = new Mesh.Vertex[mesh.VertexCount];
-		int[] indices = new int[mesh.FaceCount * 3];
+		Vector3 mins = meshes[0].Vertices[0].position;
+		Vector3 maxs = meshes[0].Vertices[0].position;
 
-		for ( int v = 0; v < mesh.VertexCount; v++ )
-		{
-			Mesh.Vertex vertex;
-			OpenTKMath.Vector2 uv0 = new();
-			OpenTKMath.Vector2 uv1 = new();
-			OpenTKMath.Vector2 uv2 = new();
-			OpenTKMath.Vector2 uv3 = new();
-
-			if ( mesh.TextureCoordinateChannelCount > 0 )
-			{
-				uv0 = new( mesh.TextureCoordinateChannels[0][v].X, mesh.TextureCoordinateChannels[0][v].Y );
-			}
-			if ( mesh.TextureCoordinateChannelCount > 1 )
-			{
-				uv1 = new( mesh.TextureCoordinateChannels[1][v].X, mesh.TextureCoordinateChannels[1][v].Y );
-			}
-			if ( mesh.TextureCoordinateChannelCount > 2 )
-			{
-				uv2 = new( mesh.TextureCoordinateChannels[2][v].X, mesh.TextureCoordinateChannels[2][v].Y );
-			}
-			if ( mesh.TextureCoordinateChannelCount > 3 )
-			{
-				uv3 = new( mesh.TextureCoordinateChannels[3][v].X, mesh.TextureCoordinateChannels[3][v].Y );
-			}
-
-			Vector3 normal = new();
-			if ( mesh.HasNormals )
-			{
-				normal = mesh.Normals[v];
-			}
-
-			Vector3 tangent = new();
-			Vector3 bitangent = new();
-			if ( mesh.HasTangentBasis )
-			{
-				tangent = mesh.Tangents[v];
-				bitangent = mesh.BiTangents[v];
-			}
-
-			Vector3 color = new();
-			if ( mesh.VertexColorChannelCount > 0 )
-			{
-				color.x = mesh.VertexColorChannels[0][v].R;
-				color.y = mesh.VertexColorChannels[0][v].G;
-				color.z = mesh.VertexColorChannels[0][v].B;
-			}
-
-			vertex = new Mesh.Vertex( mesh.Vertices[v], normal, tangent, bitangent, uv0, uv1, uv2, uv3, color );
-			vertices[v] = vertex;
-		}
-
-		for ( int fa = 0; fa < mesh.FaceCount; fa++ )
-		{
-			Face face = mesh.Faces[fa];
-			for ( int ind = 0; ind < face.IndexCount; ind++ )
-			{
-				indices[fa * 3 + ind] = face.Indices[ind];
-			}
-		}
-
-		foreach ( var vert in vertices.Reverse() )
-		{
-			vert.tangent.Normalize();
-		}
-
-		Log.Info( $"new mesh v:{vertices.Length} i:{indices.Length} mat:{scene.Materials[mesh.MaterialIndex].Name}" );
-		Mesh fmesh = new( vertices, indices, scene.Materials[mesh.MaterialIndex].Name );
-		return fmesh;
-	}
-
-	private BBox GetRenderBounds()
-	{
-		if ( Meshes is null ) return new BBox();
-		Vector3 mins = Meshes[0].Vertices[0].position;
-		Vector3 maxs = Meshes[0].Vertices[0].position;
-
-		foreach ( var mesh in Meshes )
+		foreach ( var mesh in meshes )
 		{
 			foreach ( var vertex in mesh.Vertices )
 			{
@@ -244,14 +93,14 @@ public class Model : IDisposable
 
 		return new BBox( mins, maxs );
 	}
+}
 
-	public static class Primitives
-	{
-		public static Model Axis => Load( "models/primitives/axis.fbx" );
-		public static Model Error => Load( "models/primitives/error.fbx" );
-		public static Model Cube => Load( "models/primitives/cube.fbx" );
-		public static Model InvertedCube => Load( "models/primitives/cube_inv.fbx" );
-		public static Model Sphere => Load( "models/primitives/sphere.fbx" );
-		public static Model ForwardCone => Load( "models/primitives/cone_forward.fbx" );
-	}
+public static class ModelPrimitives
+{
+	public static Model Axis => Model.Load( "models/primitives/axis.fbx" );
+	public static Model Error => Model.Load( "models/primitives/error.fbx" );
+	public static Model Cube => Model.Load( "models/primitives/cube.fbx" );
+	public static Model InvertedCube => Model.Load( "models/primitives/cube_inv.fbx" );
+	public static Model Sphere => Model.Load( "models/primitives/sphere.fbx" );
+	public static Model ForwardCone => Model.Load( "models/primitives/cone_forward.fbx" );
 }

--- a/Renderer/RenderData/ModelBuilder.cs
+++ b/Renderer/RenderData/ModelBuilder.cs
@@ -1,0 +1,166 @@
+﻿using Assimp;
+using System.Reflection;
+
+namespace Vanadium.Renderer.RenderData
+{
+	public class ModelBuilder
+	{
+		private string? name;
+		private Mesh[]? meshes;
+		private Material? materialoverride;
+
+		public ModelBuilder FromFile( string path )
+		{
+			name = path;
+			InitMeshesFromFile( path );
+			return this;
+		}
+
+		public ModelBuilder WithMaterialOverride( string? path )
+		{
+			if ( path is null )
+			{
+				materialoverride = null;
+				return this;
+			}
+			return WithMaterialOverride( Material.Load( path ) );
+		}
+
+		public ModelBuilder WithMaterialOverride( Material? mat )
+		{
+			materialoverride = mat;
+			return this;
+		}
+
+		public Model Build()
+		{
+			// apply materialoverride, if any
+			if ( meshes is not null && materialoverride is not null )
+			{
+				foreach ( var mesh in meshes )
+				{
+					mesh.Material = materialoverride;
+				}
+			}
+			return new Model( name ?? Model.Error, meshes ?? Array.Empty<Mesh>() );
+		}
+
+		private void InitMeshesFromFile( string path )
+		{
+			Log.Info( $"loading model: {path}" );
+			var fileName = Path.Combine( $"{Path.GetDirectoryName( Assembly.GetExecutingAssembly().Location )}/resources/{path}" );
+
+			AssimpContext importer = new();
+
+			Assimp.Scene? scene;
+			try
+			{
+				scene = importer.ImportFile( fileName, PostProcessPreset.TargetRealTimeMaximumQuality | PostProcessSteps.FlipUVs | PostProcessSteps.Triangulate | PostProcessSteps.CalculateTangentSpace );
+			}
+			catch ( FileNotFoundException ex )
+			{
+				Log.Info( $"ERROR IMPORTING MODEL {fileName} ({ex})" );
+				meshes = null;
+				return;
+			}
+
+			if ( scene is null || scene.SceneFlags == SceneFlags.Incomplete || scene.RootNode is null )
+			{
+				Log.Info( "ASSIMP IMPORT ERROR" );
+				return;
+			}
+
+			meshes = new Mesh[scene.MeshCount];
+			ProcessNode( scene.RootNode, scene );
+		}
+
+		private void ProcessNode( Node node, Assimp.Scene scene )
+		{
+			if ( meshes is null ) return;
+			foreach ( int index in node.MeshIndices )
+			{
+				Assimp.Mesh mesh = scene.Meshes[index];
+				meshes[index] = ProcessMesh( mesh, scene );
+			}
+			for ( int i = 0; i < node.ChildCount; i++ )
+			{
+				ProcessNode( node.Children[i], scene );
+			}
+		}
+
+		private static Mesh ProcessMesh( Assimp.Mesh mesh, Assimp.Scene scene )
+		{
+			Mesh.Vertex[] vertices = new Mesh.Vertex[mesh.VertexCount];
+			int[] indices = new int[mesh.FaceCount * 3];
+
+			for ( int v = 0; v < mesh.VertexCount; v++ )
+			{
+				Mesh.Vertex vertex;
+				OpenTKMath.Vector2 uv0 = new();
+				OpenTKMath.Vector2 uv1 = new();
+				OpenTKMath.Vector2 uv2 = new();
+				OpenTKMath.Vector2 uv3 = new();
+
+				if ( mesh.TextureCoordinateChannelCount > 0 )
+				{
+					uv0 = new( mesh.TextureCoordinateChannels[0][v].X, mesh.TextureCoordinateChannels[0][v].Y );
+				}
+				if ( mesh.TextureCoordinateChannelCount > 1 )
+				{
+					uv1 = new( mesh.TextureCoordinateChannels[1][v].X, mesh.TextureCoordinateChannels[1][v].Y );
+				}
+				if ( mesh.TextureCoordinateChannelCount > 2 )
+				{
+					uv2 = new( mesh.TextureCoordinateChannels[2][v].X, mesh.TextureCoordinateChannels[2][v].Y );
+				}
+				if ( mesh.TextureCoordinateChannelCount > 3 )
+				{
+					uv3 = new( mesh.TextureCoordinateChannels[3][v].X, mesh.TextureCoordinateChannels[3][v].Y );
+				}
+
+				Vector3 normal = new();
+				if ( mesh.HasNormals )
+				{
+					normal = mesh.Normals[v];
+				}
+
+				Vector3 tangent = new();
+				Vector3 bitangent = new();
+				if ( mesh.HasTangentBasis )
+				{
+					tangent = mesh.Tangents[v];
+					bitangent = mesh.BiTangents[v];
+				}
+
+				Vector3 color = new();
+				if ( mesh.VertexColorChannelCount > 0 )
+				{
+					color.x = mesh.VertexColorChannels[0][v].R;
+					color.y = mesh.VertexColorChannels[0][v].G;
+					color.z = mesh.VertexColorChannels[0][v].B;
+				}
+
+				vertex = new Mesh.Vertex( mesh.Vertices[v], normal, tangent, bitangent, uv0, uv1, uv2, uv3, color );
+				vertices[v] = vertex;
+			}
+
+			for ( int fa = 0; fa < mesh.FaceCount; fa++ )
+			{
+				Face face = mesh.Faces[fa];
+				for ( int ind = 0; ind < face.IndexCount; ind++ )
+				{
+					indices[fa * 3 + ind] = face.Indices[ind];
+				}
+			}
+
+			foreach ( var vert in vertices.Reverse() )
+			{
+				vert.tangent.Normalize();
+			}
+
+			Log.Info( $"new mesh v:{vertices.Length} i:{indices.Length} mat:{scene.Materials[mesh.MaterialIndex].Name}" );
+			Mesh fmesh = new( vertices, indices, scene.Materials[mesh.MaterialIndex].Name );
+			return fmesh;
+		}
+	}
+}

--- a/Renderer/scene/SceneLightManager.cs
+++ b/Renderer/scene/SceneLightManager.cs
@@ -82,7 +82,7 @@ public class SceneLightManager
 		Log.Info( $"new pointlight {light} {position} {color} {constant} {linear} {quadratic}" );
 		var lightmodel = new SceneObject
 		{
-			Model = Model.Primitives.Sphere,
+			Model = ModelPrimitives.Sphere,
 			Scale = 0.1f,
 			Position = position
 		};
@@ -121,7 +121,7 @@ public class SceneLightManager
 		Log.Info( $"new spotlight {light} {position} {rotation.Forward} {color} {innerangle} {outerangle} {constant} {linear} {quadratic}" );
 		var lightmodel = new SceneObject
 		{
-			Model = Model.Primitives.ForwardCone,
+			Model = ModelPrimitives.ForwardCone,
 			Scale = 0.1f,
 			Position = position,
 			Rotation = rotation
@@ -159,7 +159,7 @@ public class SceneLightManager
 		Log.Info( $"new dirlight {light} {rotation.Forward} {color}" );
 		var lightmodel = new SceneObject
 		{
-			Model = Model.Primitives.ForwardCone,
+			Model = ModelPrimitives.ForwardCone,
 			Scale = 0.1f,
 			Position = Vector3.Zero,
 			Rotation = rotation

--- a/Renderer/scene/SceneObject.cs
+++ b/Renderer/scene/SceneObject.cs
@@ -2,42 +2,17 @@
 
 public class SceneObject
 {
-	private Model? _model;
-	public Model? Model
+	private Model _model;
+	public Model Model
 	{
 		get
 		{
-			return _model ?? Model.Primitives.Error;
+			return _model.IsError ? ModelPrimitives.Error : _model;
 		}
 		set
 		{
 			_model = value;
 			PostModelSet();
-		}
-	}
-
-	public void SetMaterialOverride( string path )
-	{
-		MaterialOverride = Material.Load( path );
-	}
-
-	private Material? _materialoverride;
-	public Material? MaterialOverride
-	{
-		get
-		{ 
-			return _materialoverride; 
-		}
-		set
-		{
-			if ( Model is null ) return;
-			if ( value is null )
-			{
-				Model.SetupMeshes();
-				return;
-			}
-			Model.SetMeshMaterials( value );
-			_materialoverride = value;
 		}
 	}
 
@@ -126,7 +101,6 @@ public class SceneObject
 
 	private void PostModelSet()
 	{
-		if ( Model is null ) return;
 		var transparent = false;
 
 		if ( Model.Meshes is not null )
@@ -155,7 +129,7 @@ public class SceneObject
 
 	public void Draw()
 	{
-		Model?.Draw( this );
+		Model.Draw( this );
 		OnRender();
 	}
 

--- a/Renderer/scene/Skybox.cs
+++ b/Renderer/scene/Skybox.cs
@@ -13,11 +13,11 @@ public class Skybox
 		ActiveSkybox = skybox;
 	}
 
-	private Model? Model;
+	private Model Model;
 
 	public void Setup( string path )
 	{
-		Model = Model.Primitives.InvertedCube;
+		Model = ModelPrimitives.InvertedCube;
 		Model.SetMaterialOverride( path );
 	}
 
@@ -25,7 +25,7 @@ public class Skybox
 	{
 		GL.DepthFunc( DepthFunction.Lequal );
 
-		Model?.Draw();
+		Model.Draw();
 
 		GL.DepthFunc( DepthFunction.Less );
 	}

--- a/Window.cs
+++ b/Window.cs
@@ -72,11 +72,11 @@ public class Window : GameWindow
 			Position = Vector3.Down,
 			Scale = 0.5f
 		};
-		floor.SetMaterialOverride( "materials/pbrtest/tiles.vanmat" );
+		floor.Model.SetMaterialOverride( "materials/pbrtest/tiles.vanmat" );
 
 		_ = new SceneObject
 		{
-			Model = Model.Primitives.Axis
+			Model = ModelPrimitives.Axis
 		};
 
 		// init camera
@@ -215,14 +215,14 @@ public class Window : GameWindow
 
 			if ( Input.IsPressed( MouseButton.Left ) )
 			{
-				_ = new SceneObject
+				var sphere = new SceneObject
 				{
 					Position = cam.Position + cam.Rotation.Forward * 3,
 					//Rotation = cam.Rotation,
-					Model = Model.Load( "models/cannon.fbx" ),
+					Model = ModelPrimitives.Sphere,//Model.Load( "models/cannon.fbx" ),
 					//Scale = 0.3f
 				};
-				//sphere.SetMaterialOverride( "materials/discoball.vanmat" );
+				sphere.Model.SetMaterialOverride( "materials/discoball.vanmat" );
 
 				//DebugDraw.Box( cam.Position, new Vector3( 0.2f, 0.2f, 0.2f ), -new Vector3( 0.2f, 0.2f, 0.2f ), Color.Green, 100, false );
 				//DebugDraw.Line( cam.Position, cam.Position + cam.Rotation.Forward * 5, Color.White, 100, false );


### PR DESCRIPTION
Made Model a struct and used a builder pattern to get Models. They're still cached but we copy them by value now to have per-model data. I originally did this to fix an issue with material overrides but realized this issue goes all the way to the actual meshes. I'm not sure if I can/should just turn meshes to structs as well, since I'm not sure how I would handle cleanup in that case. I'm going to leave it as it is for now and figure out a better way to do material overrides with proper attribute setups later.