### PR TITLE
Refactor/uniform buffer manager

### DIFF
--- a/Renderer/RenderData/Buffers/Buffer.cs
+++ b/Renderer/RenderData/Buffers/Buffer.cs
@@ -4,10 +4,12 @@ public abstract class Buffer
 {
 	public readonly int Handle;
 	public readonly string Name;
+	public readonly int Size;
 
-	public Buffer( int handle, string name )
+	public Buffer( int handle, string name, int size )
 	{
 		Handle = handle;
 		Name = name;
+		Size = size;
 	}
 }

--- a/Renderer/RenderData/Buffers/Buffer.cs
+++ b/Renderer/RenderData/Buffers/Buffer.cs
@@ -1,0 +1,13 @@
+﻿namespace Vanadium.Renderer.RenderData.Buffers;
+
+public abstract class Buffer
+{
+	public readonly int Handle;
+	public readonly string Name;
+
+	public Buffer( int handle, string name )
+	{
+		Handle = handle;
+		Name = name;
+	}
+}

--- a/Renderer/RenderData/Buffers/BufferData/BufferArrayData.cs
+++ b/Renderer/RenderData/Buffers/BufferData/BufferArrayData.cs
@@ -49,18 +49,15 @@ public class BufferArrayData<T> : IBufferSetting
 
 	public void Set( Buffer buffer )
 	{
-		GL.BindBuffer( BufferTarget.UniformBuffer, buffer.Handle );
-
 		// get IntPtr from data
 		var handle = GCHandle.Alloc( Value, GCHandleType.Pinned );
 		var data = handle.AddrOfPinnedObject();
 
 		// push data to buffer
-		GL.BufferSubData( BufferTarget.UniformBuffer, (IntPtr)Offset, sizeof( int ), data );
+		GL.BufferSubData( BufferTarget.UniformBuffer, (IntPtr)Offset, Size, data );
 
 		// free handle
 		handle.Free();
-		GL.BindBuffer( BufferTarget.UniformBuffer, 0 );
 
 		_IsDirty = false;
 	}

--- a/Renderer/RenderData/Buffers/BufferData/BufferArrayData.cs
+++ b/Renderer/RenderData/Buffers/BufferData/BufferArrayData.cs
@@ -1,4 +1,7 @@
-﻿namespace Vanadium.Renderer.RenderData.Buffers.BufferData;
+﻿using OpenTK.Graphics.OpenGL4;
+using System.Runtime.InteropServices;
+
+namespace Vanadium.Renderer.RenderData.Buffers.BufferData;
 
 public class BufferArrayData<T> : IBufferSetting
 {
@@ -46,6 +49,19 @@ public class BufferArrayData<T> : IBufferSetting
 
 	public void Set( Buffer buffer )
 	{
+		GL.BindBuffer( BufferTarget.UniformBuffer, buffer.Handle );
 
+		// get IntPtr from data
+		var handle = GCHandle.Alloc( Value, GCHandleType.Pinned );
+		var data = handle.AddrOfPinnedObject();
+
+		// push data to buffer
+		GL.BufferSubData( BufferTarget.UniformBuffer, (IntPtr)Offset, sizeof( int ), data );
+
+		// free handle
+		handle.Free();
+		GL.BindBuffer( BufferTarget.UniformBuffer, 0 );
+
+		_IsDirty = false;
 	}
 }

--- a/Renderer/RenderData/Buffers/BufferData/BufferArrayData.cs
+++ b/Renderer/RenderData/Buffers/BufferData/BufferArrayData.cs
@@ -1,0 +1,51 @@
+﻿namespace Vanadium.Renderer.RenderData.Buffers.BufferData;
+
+public class BufferArrayData<T> : IBufferSetting
+{
+	/// <summary>
+	/// name of the key for this data
+	/// </summary>
+	public readonly string Name;
+	/// <summary>
+	/// data offset into its buffer in bytes
+	/// </summary>
+	public readonly int Offset;
+	/// <summary>
+	/// total size of the allocated data in bytes
+	/// </summary>
+	public readonly int Size;
+	/// <summary>
+	/// length of the array
+	/// </summary>
+	public readonly int DataLength;
+
+	private T[]? _Value;
+	public T[]? Value
+	{
+		get => _Value;
+		set
+		{
+			_Value = value?.Take( DataLength ).ToArray();
+			SetDirty();
+		}
+	}
+
+	private bool _IsDirty;
+	public bool IsDirty { get => _IsDirty; }
+
+	public void SetDirty() => _IsDirty = true;
+
+	public BufferArrayData( string name, int offset, int size, int datalength )
+	{
+		Name = name;
+		Offset = offset;
+		Size = size;
+		DataLength = datalength;
+		Value = default;
+	}
+
+	public void Set( Buffer buffer )
+	{
+
+	}
+}

--- a/Renderer/RenderData/Buffers/BufferData/BufferData.cs
+++ b/Renderer/RenderData/Buffers/BufferData/BufferData.cs
@@ -44,18 +44,15 @@ public class BufferData<T> : IBufferSetting
 
 	public void Set( Buffer buffer )
 	{
-		GL.BindBuffer( BufferTarget.UniformBuffer, buffer.Handle );
-
 		// get IntPtr from data
 		var handle = GCHandle.Alloc( Value, GCHandleType.Pinned );
 		var data = handle.AddrOfPinnedObject();
 
 		// push data to buffer
-		GL.BufferSubData( BufferTarget.UniformBuffer, (IntPtr)Offset, sizeof( int ), data );
+		GL.BufferSubData( BufferTarget.UniformBuffer, (IntPtr)Offset, Size, data );
 
 		// free handle
 		handle.Free();
-		GL.BindBuffer( BufferTarget.UniformBuffer, 0 );
 
 		_IsDirty = false;
 	}

--- a/Renderer/RenderData/Buffers/BufferData/BufferData.cs
+++ b/Renderer/RenderData/Buffers/BufferData/BufferData.cs
@@ -1,0 +1,45 @@
+﻿namespace Vanadium.Renderer.RenderData.Buffers.BufferData;
+
+public class BufferData<T> : IBufferSetting
+{
+	/// <summary>
+	/// name of the key for this data
+	/// </summary>
+	public readonly string Name;
+	/// <summary>
+	/// data offset into its buffer in bytes
+	/// </summary>
+	public readonly int Offset;
+	/// <summary>
+	/// total size of the allocated data in bytes
+	/// </summary>
+	public readonly int Size;
+
+	private T? _Value;
+	public T? Value
+	{
+		get => _Value;
+		set
+		{
+			_Value = value;
+			SetDirty();
+		}
+	}
+
+	private bool _IsDirty;
+	public bool IsDirty { get => _IsDirty; }
+
+	public void SetDirty() => _IsDirty = true;
+
+	public BufferData( string name, int offset, int size )
+	{
+		Name = name;
+		Offset = offset;
+		Size = size;
+		Value = default;
+	}
+
+	public void Set( Buffer buffer )
+	{
+	}
+}

--- a/Renderer/RenderData/Buffers/BufferData/BufferData.cs
+++ b/Renderer/RenderData/Buffers/BufferData/BufferData.cs
@@ -1,4 +1,7 @@
-﻿namespace Vanadium.Renderer.RenderData.Buffers.BufferData;
+﻿using OpenTK.Graphics.OpenGL4;
+using System.Runtime.InteropServices;
+
+namespace Vanadium.Renderer.RenderData.Buffers.BufferData;
 
 public class BufferData<T> : IBufferSetting
 {
@@ -41,5 +44,19 @@ public class BufferData<T> : IBufferSetting
 
 	public void Set( Buffer buffer )
 	{
+		GL.BindBuffer( BufferTarget.UniformBuffer, buffer.Handle );
+
+		// get IntPtr from data
+		var handle = GCHandle.Alloc( Value, GCHandleType.Pinned );
+		var data = handle.AddrOfPinnedObject();
+
+		// push data to buffer
+		GL.BufferSubData( BufferTarget.UniformBuffer, (IntPtr)Offset, sizeof( int ), data );
+
+		// free handle
+		handle.Free();
+		GL.BindBuffer( BufferTarget.UniformBuffer, 0 );
+
+		_IsDirty = false;
 	}
 }

--- a/Renderer/RenderData/Buffers/BufferData/IBufferSetting.cs
+++ b/Renderer/RenderData/Buffers/BufferData/IBufferSetting.cs
@@ -1,0 +1,7 @@
+﻿namespace Vanadium.Renderer.RenderData.Buffers.BufferData;
+
+public interface IBufferSetting
+{
+	public bool IsDirty { get; }
+	public abstract void Set( Buffer buffer );
+}

--- a/Renderer/RenderData/Buffers/UniformBuffer.cs
+++ b/Renderer/RenderData/Buffers/UniformBuffer.cs
@@ -1,0 +1,34 @@
+﻿namespace Vanadium.Renderer.RenderData.Buffers;
+
+public class UniformBuffer
+{
+	public readonly int Handle;
+	public readonly string Name;
+
+	public static HashSet<UniformBuffer> All = new HashSet<UniformBuffer>();
+
+	public UniformBuffer( int handle, string name )	{
+		Handle = handle;
+		Name = name;
+	}
+
+	/// <summary>
+	/// Start a buffer declaration with a given buffer handle name.
+	/// </summary>
+	/// <param name="name">The name of the buffer handle.</param>
+	/// <returns>A UniformBufferBuilder instance, used to construct the UniformBuffer object.</returns>
+	public static UniformBufferBuilder DeclareBuffer( string name )
+	{
+		UniformBufferBuilder builder = new UniformBufferBuilder( name );
+		return builder;
+	}
+
+	/// <summary>
+	/// Initializes the buffer's data.
+	/// </summary>
+	/// <exception cref="NotImplementedException"></exception>
+	public void Initialize()
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/Renderer/RenderData/Buffers/UniformBuffer.cs
+++ b/Renderer/RenderData/Buffers/UniformBuffer.cs
@@ -15,6 +15,41 @@ public partial class UniformBuffer : Buffer
 		InternalBufferData = bufferdata;
 	}
 
+	public static void InitCore()
+	{
+		// init scene uniform buffer for general rendering
+		DeclareBuffer( "SceneUniformBuffer" )
+			// matrices
+			.AddField<OpenTKMath.Matrix4>( "g_matWorldToProjection" )
+			.AddField<OpenTKMath.Matrix4>( "g_matWorldToView" )
+			// camera
+			.AddField<Vector3>( "g_vCameraPositionWs", 4 )
+			.AddField<Vector3>( "g_vCameraDirWs", 4 )
+			.AddField<Vector3>( "g_vCameraUpDirWs", 4 )
+			// viewport
+			.AddField<OpenTKMath.Vector2i>( "g_vViewportSize" )
+			// float vars
+			.AddField<float>( "g_flTime" )
+			.AddField<float>( "g_flNearPlane" )
+			.AddField<float>( "g_flFarPlane" )
+			.AddField<float>( "g_flGamma" )
+			.Build();
+
+		// init scene lighting buffer
+		DeclareBuffer( "SceneLightingUniformBuffer" )
+			// ambient color
+			.AddField<Color>( "g_vAmbientLightingColor" )
+			// light humbers
+			.AddField<int>( "g_nNumPointlights" )
+			.AddField<int>( "g_nNumSpotlights" )
+			.AddField<int>( "g_nNumDirlights" )
+			// lights
+			.AddArrayField<SceneLightManager.PointLight[]>( "g_PointLights", SceneLightManager.MaxPointLights )
+			.AddArrayField<SceneLightManager.SpotLight[]>( "g_SpotLights", SceneLightManager.MaxSpotLights )
+			.AddArrayField<SceneLightManager.DirLight[]>( "g_DirLights", SceneLightManager.MaxDirLights )
+			.Build();
+	}
+
 	/// <summary>
 	/// Try to set the data of a BufferData entry.
 	/// </summary>
@@ -87,7 +122,7 @@ public partial class UniformBuffer : Buffer
 	public void Set<T>( string name, T[] data )
 	{
 		if ( InternalBufferData[name] is not BufferArrayData<T> entry )
-			throw new ArgumentException( $"Invalid type for BufferData entry at {name}." );
+			throw new ArgumentException( $"Invalid type for BufferArrayData entry at {name}." );
 		entry.Value = data;
 	}
 
@@ -114,9 +149,9 @@ public partial class UniformBuffer : Buffer
 		GL.BindBuffer( BufferTarget.UniformBuffer, Handle );
 		var size = Size.RoundUpToMultipleOf( 16 );
 		GL.BufferData( BufferTarget.UniformBuffer, size, IntPtr.Zero, BufferUsageHint.StaticDraw );
-		GL.BindBufferRange( BufferRangeTarget.UniformBuffer, 0, Handle, IntPtr.Zero, size );
+		GL.BindBufferRange( BufferRangeTarget.UniformBuffer, All.Count - 1, Handle, IntPtr.Zero, size );
 
-		GL.BindBuffer( BufferTarget.UniformBuffer, 0 );
+		Log.Info( $"Initialized buffer {Name} : {Handle}" );
 	}
 
 	public static void UpdateAll()
@@ -138,6 +173,5 @@ public partial class UniformBuffer : Buffer
 			// set data on the buffer
 			entry.Value.Set( this );
 		}
-		GL.BindBuffer( BufferTarget.UniformBuffer, 0 );
 	}
 }

--- a/Renderer/RenderData/Buffers/UniformBuffer.cs
+++ b/Renderer/RenderData/Buffers/UniformBuffer.cs
@@ -42,7 +42,7 @@ public partial class UniformBuffer : Buffer
 			// light humbers
 			.AddField<int>( "g_nNumPointlights" )
 			.AddField<int>( "g_nNumSpotlights" )
-			.AddField<int>( "g_nNumDirlights" )
+			.AddField<int>( "g_nNumDirlights", 4 )
 			// lights
 			.AddArrayField<SceneLightManager.PointLight>( "g_PointLights", SceneLightManager.MaxPointLights )
 			.AddArrayField<SceneLightManager.SpotLight>( "g_SpotLights", SceneLightManager.MaxSpotLights )

--- a/Renderer/RenderData/Buffers/UniformBuffer.cs
+++ b/Renderer/RenderData/Buffers/UniformBuffer.cs
@@ -44,9 +44,9 @@ public partial class UniformBuffer : Buffer
 			.AddField<int>( "g_nNumSpotlights" )
 			.AddField<int>( "g_nNumDirlights" )
 			// lights
-			.AddArrayField<SceneLightManager.PointLight[]>( "g_PointLights", SceneLightManager.MaxPointLights )
-			.AddArrayField<SceneLightManager.SpotLight[]>( "g_SpotLights", SceneLightManager.MaxSpotLights )
-			.AddArrayField<SceneLightManager.DirLight[]>( "g_DirLights", SceneLightManager.MaxDirLights )
+			.AddArrayField<SceneLightManager.PointLight>( "g_PointLights", SceneLightManager.MaxPointLights )
+			.AddArrayField<SceneLightManager.SpotLight>( "g_SpotLights", SceneLightManager.MaxSpotLights )
+			.AddArrayField<SceneLightManager.DirLight>( "g_DirLights", SceneLightManager.MaxDirLights )
 			.Build();
 	}
 

--- a/Renderer/RenderData/Buffers/UniformBuffer.cs
+++ b/Renderer/RenderData/Buffers/UniformBuffer.cs
@@ -23,9 +23,12 @@ public partial class UniformBuffer : Buffer
 			.AddField<OpenTKMath.Matrix4>( "g_matWorldToProjection" )
 			.AddField<OpenTKMath.Matrix4>( "g_matWorldToView" )
 			// camera
-			.AddField<Vector3>( "g_vCameraPositionWs", 4 )
-			.AddField<Vector3>( "g_vCameraDirWs", 4 )
-			.AddField<Vector3>( "g_vCameraUpDirWs", 4 )
+			.AddField<Vector3>( "g_vCameraPositionWs" )
+			.AddPadding()
+			.AddField<Vector3>( "g_vCameraDirWs" )
+			.AddPadding()
+			.AddField<Vector3>( "g_vCameraUpDirWs" )
+			.AddPadding()
 			// viewport
 			.AddField<OpenTKMath.Vector2i>( "g_vViewportSize" )
 			// float vars
@@ -39,10 +42,11 @@ public partial class UniformBuffer : Buffer
 		DeclareBuffer( "SceneLightingUniformBuffer" )
 			// ambient color
 			.AddField<Color>( "g_vAmbientLightingColor" )
-			// light humbers
+			// light numbers
 			.AddField<int>( "g_nNumPointlights" )
 			.AddField<int>( "g_nNumSpotlights" )
-			.AddField<int>( "g_nNumDirlights", 4 )
+			.AddField<int>( "g_nNumDirlights" )
+			.AddPadding()
 			// lights
 			.AddArrayField<SceneLightManager.PointLight>( "g_PointLights", SceneLightManager.MaxPointLights )
 			.AddArrayField<SceneLightManager.SpotLight>( "g_SpotLights", SceneLightManager.MaxSpotLights )

--- a/Renderer/RenderData/Buffers/UniformBuffer.cs
+++ b/Renderer/RenderData/Buffers/UniformBuffer.cs
@@ -1,15 +1,93 @@
-﻿namespace Vanadium.Renderer.RenderData.Buffers;
+﻿using Vanadium.Renderer.RenderData.Buffers.BufferData;
 
-public class UniformBuffer
+namespace Vanadium.Renderer.RenderData.Buffers;
+
+public partial class UniformBuffer : Buffer
 {
-	public readonly int Handle;
-	public readonly string Name;
-
 	public static HashSet<UniformBuffer> All = new HashSet<UniformBuffer>();
 
-	public UniformBuffer( int handle, string name )	{
-		Handle = handle;
-		Name = name;
+	public IReadOnlyDictionary<string, IBufferSetting> BufferData => InternalBufferData;
+	private Dictionary<string, IBufferSetting> InternalBufferData = new();
+
+	public UniformBuffer( int handle, string name, Dictionary<string, IBufferSetting> bufferdata ) : base( handle, name )
+	{
+		InternalBufferData = bufferdata;
+	}
+
+	/// <summary>
+	/// Try to set the data of a BufferData entry.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="name">The name of the BufferData entry.</param>
+	/// <param name="data">The data to set.</param>
+	/// <returns>True if the entry was found and set, false otherwise.</returns>
+	public bool TrySet<T>( string name, T data )
+	{
+		if ( !InternalBufferData.ContainsKey( name ) )
+			return false;
+
+		var entry = InternalBufferData[name];
+
+		if ( entry is not BufferData<T> bufferdata )
+			return false;
+
+		bufferdata.Value = data;
+
+		return true;
+	}
+
+	/// <summary>
+	/// Try to set the data of a BufferArrayData entry.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="name">The name of the BufferArrayData entry.</param>
+	/// <param name="data">The data to set.</param>
+	/// <returns>True if the entry was found and set, false otherwise.</returns>
+	public bool TrySet<T>( string name, T[] data )
+	{
+		if ( !InternalBufferData.ContainsKey( name ) )
+			return false;
+
+		var entry = InternalBufferData[name];
+
+		if ( entry is not BufferArrayData<T> bufferdata )
+			return false;
+
+		bufferdata.Value = data;
+
+		return true;
+	}
+
+	/// <summary>
+	/// Set the data of a BufferData entry.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="name">The name of the BufferData entry.</param>
+	/// <param name="data">The data to set.</param>
+	/// <remarks>Will throw if setting the data was not possible due to invalid name key or data type.</remarks>
+	/// <exception cref="KeyNotFoundException"></exception>
+	/// <exception cref="ArgumentException"></exception>
+	public void Set<T>( string name, T data )
+	{
+		if ( InternalBufferData[name] is not BufferData<T> entry )
+			throw new ArgumentException( $"Invalid type for BufferData entry at {name}." );
+		entry.Value = data;
+	}
+
+	/// <summary>
+	/// Set the data of a BufferArrayData entry.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="name">The name of the BufferArrayData entry.</param>
+	/// <param name="data">The data to set.</param>
+	/// <remarks>Will throw if setting the data was not possible due to invalid name key or data type.</remarks>
+	/// <exception cref="KeyNotFoundException"></exception>
+	/// <exception cref="ArgumentException"></exception>
+	public void Set<T>( string name, T[] data )
+	{
+		if ( InternalBufferData[name] is not BufferArrayData<T> entry )
+			throw new ArgumentException( $"Invalid type for BufferData entry at {name}." );
+		entry.Value = data;
 	}
 
 	/// <summary>

--- a/Renderer/RenderData/Buffers/UniformBuffer.cs
+++ b/Renderer/RenderData/Buffers/UniformBuffer.cs
@@ -1,4 +1,5 @@
-﻿using Vanadium.Renderer.RenderData.Buffers.BufferData;
+﻿using OpenTK.Graphics.OpenGL4;
+using Vanadium.Renderer.RenderData.Buffers.BufferData;
 
 namespace Vanadium.Renderer.RenderData.Buffers;
 
@@ -9,7 +10,7 @@ public partial class UniformBuffer : Buffer
 	public IReadOnlyDictionary<string, IBufferSetting> BufferData => InternalBufferData;
 	private Dictionary<string, IBufferSetting> InternalBufferData = new();
 
-	public UniformBuffer( int handle, string name, Dictionary<string, IBufferSetting> bufferdata ) : base( handle, name )
+	public UniformBuffer( int handle, string name, int size, Dictionary<string, IBufferSetting> bufferdata ) : base( handle, name, size )
 	{
 		InternalBufferData = bufferdata;
 	}
@@ -102,11 +103,16 @@ public partial class UniformBuffer : Buffer
 	}
 
 	/// <summary>
-	/// Initializes the buffer's data.
+	/// Initializes the buffer's structure.
 	/// </summary>
 	/// <exception cref="NotImplementedException"></exception>
 	public void Initialize()
 	{
-		throw new NotImplementedException();
+		GL.BindBuffer( BufferTarget.UniformBuffer, Handle );
+		var size = Size.RoundUpToMultipleOf( 16 );
+		GL.BufferData( BufferTarget.UniformBuffer, size, IntPtr.Zero, BufferUsageHint.StaticDraw );
+		GL.BindBufferRange( BufferRangeTarget.UniformBuffer, 0, Handle, IntPtr.Zero, size );
+
+		GL.BindBuffer( BufferTarget.UniformBuffer, 0 );
 	}
 }

--- a/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
+++ b/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
@@ -66,10 +66,10 @@ public class UniformBufferBuilder
 		if ( postpad < 0 )
 			throw new BufferFieldFormatException( "BufferArrayData postpad cannot be smaller than 0.", nameof( postpad ) );
 
-		var size = Marshal.SizeOf( typeof( T ) ) * length;
+		var size = Marshal.SizeOf( typeof( T ).GetElementType() ) * length;
 
 		// increment with data size and pad
-		BufferData.Add( identifier, new BufferData<T>( identifier, Count, size ) );
+		BufferData.Add( identifier, new BufferArrayData<T>( identifier, Count, size, length ) );
 		Count += size + postpad;
 
 		return this;
@@ -98,6 +98,7 @@ public class UniformBufferBuilder
 
 		// add to static hashset so we can keep track of it
 		UniformBuffer.All.Add( Name, buffer );
+		Log.Info( $"built buffer {Name} : {handle} and size {Count}" );
 		// init buffer
 		buffer.Initialize();
 		return buffer;

--- a/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
+++ b/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
@@ -12,34 +12,77 @@ public class UniformBufferBuilder
 	public UniformBufferBuilder( string name )
 	{
 		Name = name;
-		Count = default;
+		Count = 0;
 	}
 
+	/// <summary>
+	/// Add a new field to the UniformBufferBuilder.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="identifier">The identifier of the field.</param>
+	/// <param name="postpad">How much padding to add after the field, in bytes.</param>
+	/// <returns></returns>
+	/// <exception cref="BufferFieldFormatException"></exception>
 	public UniformBufferBuilder AddField<T>( string identifier, int postpad = 0 )
 	{
 		if ( typeof( T ).IsArray )
-			throw new ArgumentException( "Unable to add Array type as BufferData, use AddArrayField<T> instead." );
+			throw new BufferFieldFormatException( "Unable to add Array type as BufferData, use AddArrayField<T> instead." );
+
+		if ( string.IsNullOrWhiteSpace( identifier ) )
+			throw new BufferFieldFormatException( "BufferData name cannot be empty.", nameof( identifier ) );
+
+		if ( postpad < 0 )
+			throw new BufferFieldFormatException( "BufferData postpad cannot be smaller than 0.", nameof( postpad ) );
 
 		var size = Marshal.SizeOf( typeof( T ) );
 
 		// increment with data size and pad
-		Count += size + postpad;
 		BufferData.Add( identifier, new BufferData<T>( identifier, Count, size ) );
+		Count += size + postpad;
 
 		return this;
 	}
 
+	/// <summary>
+	/// Add a new array field to the UniformBufferBuilder.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="identifier">The identifier of the array field.</param>
+	/// <param name="length">The intended length of the array field.</param>
+	/// <param name="postpad">How much padding to add after the array field, in bytes.</param>
+	/// <returns></returns>
+	/// <exception cref="BufferFieldFormatException"></exception>
 	public UniformBufferBuilder AddArrayField<T>( string identifier, int length, int postpad = 0 )
 	{
 		if ( !typeof( T ).IsArray )
-			throw new ArgumentException( "Unable to add non-Array type as BufferData, use AddField<T> instead." );
+			throw new BufferFieldFormatException( "Unable to add non-Array type as BufferData, use AddField<T> instead." );
+
+		if ( string.IsNullOrWhiteSpace( identifier ) )
+			throw new BufferFieldFormatException( "BufferArrayData name cannot be empty.", nameof( identifier ) );
+
+		if ( length <= 0 )
+			throw new BufferFieldFormatException( "BufferArrayData length must be larger than 0.", nameof( length ) );
+
+		if ( postpad < 0 )
+			throw new BufferFieldFormatException( "BufferArrayData postpad cannot be smaller than 0.", nameof( postpad ) );
 
 		var size = Marshal.SizeOf( typeof( T ) ) * length;
 
 		// increment with data size and pad
-		Count += size + postpad;
 		BufferData.Add( identifier, new BufferData<T>( identifier, Count, size ) );
+		Count += size + postpad;
 
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a standard int sized padding to the current UniformBufferBuilder.
+	/// </summary>
+	/// <param name="count">How many int sized pads to add.</param>
+	/// <returns></returns>
+	public UniformBufferBuilder AddPadding( int count = 1 )
+	{
+		Count += count * sizeof( int );
 		return this;
 	}
 
@@ -54,9 +97,16 @@ public class UniformBufferBuilder
 		var buffer = new UniformBuffer( handle, Name, Count, BufferData );
 
 		// add to static hashset so we can keep track of it
-		UniformBuffer.All.Add( buffer );
+		UniformBuffer.All.Add( Name, buffer );
 		// init buffer
 		buffer.Initialize();
 		return buffer;
+	}
+
+	public class BufferFieldFormatException : ArgumentException
+	{
+		public BufferFieldFormatException() : base() { }
+		public BufferFieldFormatException( string? message ) : base( message ) { }
+		public BufferFieldFormatException( string? message, string? paramname ) : base( message, paramname ) { }
 	}
 }

--- a/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
+++ b/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
@@ -1,16 +1,39 @@
-﻿namespace Vanadium.Renderer.RenderData.Buffers;
+﻿using System.Runtime.InteropServices;
+using Vanadium.Renderer.RenderData.Buffers.BufferData;
+
+namespace Vanadium.Renderer.RenderData.Buffers;
 
 public class UniformBufferBuilder
 {
 	private readonly string Name;
+	private Dictionary<string, IBufferSetting> BufferData = new();
+	private int Count;
 
 	public UniformBufferBuilder( string name )
 	{
 		Name = name;
+		Count = default;
 	}
 
-	public UniformBufferBuilder AddField<T>( string identifier )
+	public UniformBufferBuilder AddField<T>( string identifier, int postpad = 0 )
 	{
+		if ( typeof( T ).IsArray )
+			throw new ArgumentException( "Unable to add Array type as BufferData, use AddArrayField<T> instead." );
+
+		var size = Marshal.SizeOf( typeof( T ) );
+
+		// increment with data size and pad
+		Count += size + postpad;
+		BufferData.Add( identifier, new BufferData<T>( identifier, Count, size ) );
+
+		return this;
+	}
+
+	public UniformBufferBuilder AddArrayField<T>( string identifier, int length, int postpad = 0 )
+	{
+		if ( !typeof( T ).IsArray )
+			throw new ArgumentException( "Unable to add non-Array type as BufferData, use AddField<T> instead." );
+
 		return this;
 	}
 

--- a/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
+++ b/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
@@ -1,0 +1,33 @@
+﻿namespace Vanadium.Renderer.RenderData.Buffers;
+
+public class UniformBufferBuilder
+{
+	private readonly string Name;
+
+	public UniformBufferBuilder( string name )
+	{
+		Name = name;
+	}
+
+	public UniformBufferBuilder AddField<T>( string identifier )
+	{
+		return this;
+	}
+
+	/// <summary>
+	/// Builds and initializes the builder's UniformBuffer object.
+	/// </summary>
+	/// <returns>An instance of the UniformBuffer object.</returns>
+	public UniformBuffer Build()
+	{
+		// create empty buffer handle
+		GLUtil.CreateBuffer( Name, out var handle );
+		var buffer = new UniformBuffer( handle, Name );
+
+		// add to static hashset so we can keep track of it
+		UniformBuffer.All.Add( buffer );
+		// init buffer
+		buffer.Initialize();
+		return buffer;
+	}
+}

--- a/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
+++ b/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
@@ -34,6 +34,12 @@ public class UniformBufferBuilder
 		if ( !typeof( T ).IsArray )
 			throw new ArgumentException( "Unable to add non-Array type as BufferData, use AddField<T> instead." );
 
+		var size = Marshal.SizeOf( typeof( T ) ) * length;
+
+		// increment with data size and pad
+		Count += size + postpad;
+		BufferData.Add( identifier, new BufferData<T>( identifier, Count, size ) );
+
 		return this;
 	}
 
@@ -45,7 +51,7 @@ public class UniformBufferBuilder
 	{
 		// create empty buffer handle
 		GLUtil.CreateBuffer( Name, out var handle );
-		var buffer = new UniformBuffer( handle, Name );
+		var buffer = new UniformBuffer( handle, Name, BufferData );
 
 		// add to static hashset so we can keep track of it
 		UniformBuffer.All.Add( buffer );

--- a/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
+++ b/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
@@ -25,9 +25,6 @@ public class UniformBufferBuilder
 	/// <exception cref="BufferFieldFormatException"></exception>
 	public UniformBufferBuilder AddField<T>( string identifier, int postpad = 0 )
 	{
-		if ( typeof( T ).IsArray )
-			throw new BufferFieldFormatException( "Unable to add Array type as BufferData, use AddArrayField<T> instead." );
-
 		if ( string.IsNullOrWhiteSpace( identifier ) )
 			throw new BufferFieldFormatException( "BufferData name cannot be empty.", nameof( identifier ) );
 
@@ -54,9 +51,6 @@ public class UniformBufferBuilder
 	/// <exception cref="BufferFieldFormatException"></exception>
 	public UniformBufferBuilder AddArrayField<T>( string identifier, int length, int postpad = 0 )
 	{
-		if ( !typeof( T ).IsArray )
-			throw new BufferFieldFormatException( "Unable to add non-Array type as BufferData, use AddField<T> instead." );
-
 		if ( string.IsNullOrWhiteSpace( identifier ) )
 			throw new BufferFieldFormatException( "BufferArrayData name cannot be empty.", nameof( identifier ) );
 
@@ -66,7 +60,7 @@ public class UniformBufferBuilder
 		if ( postpad < 0 )
 			throw new BufferFieldFormatException( "BufferArrayData postpad cannot be smaller than 0.", nameof( postpad ) );
 
-		var size = Marshal.SizeOf( typeof( T ).GetElementType() ) * length;
+		var size = Marshal.SizeOf( typeof( T ) ) * length;
 
 		// increment with data size and pad
 		BufferData.Add( identifier, new BufferArrayData<T>( identifier, Count, size, length ) );

--- a/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
+++ b/Renderer/RenderData/Buffers/UniformBufferBuilder.cs
@@ -51,7 +51,7 @@ public class UniformBufferBuilder
 	{
 		// create empty buffer handle
 		GLUtil.CreateBuffer( Name, out var handle );
-		var buffer = new UniformBuffer( handle, Name, BufferData );
+		var buffer = new UniformBuffer( handle, Name, Count, BufferData );
 
 		// add to static hashset so we can keep track of it
 		UniformBuffer.All.Add( buffer );

--- a/Renderer/RenderData/Buffers/UniformBufferManager.cs
+++ b/Renderer/RenderData/Buffers/UniformBufferManager.cs
@@ -1,7 +1,7 @@
 ﻿using OpenTK.Graphics.OpenGL4;
 using System.Runtime.InteropServices;
 
-namespace Vanadium.Renderer.RenderData;
+namespace Vanadium.Renderer.RenderData.Buffers;
 
 public class UniformBufferManager
 {

--- a/Renderer/RenderData/Buffers/UniformBufferManager.cs
+++ b/Renderer/RenderData/Buffers/UniformBufferManager.cs
@@ -1,33 +1,12 @@
-﻿using OpenTK.Graphics.OpenGL4;
-using System.Runtime.InteropServices;
-
-namespace Vanadium.Renderer.RenderData.Buffers;
+﻿namespace Vanadium.Renderer.RenderData.Buffers;
 
 public class UniformBufferManager
 {
-	public int SceneLightingUniformBufferHandle;
 	public static UniformBufferManager? Current { get; private set; }
 
 	public UniformBufferManager()
 	{
 		Current = this;
-	}
-
-	public void Init()
-	{
-		// setup per view lighting uniform buffer
-		GLUtil.CreateBuffer( "SceneLightingUniformBuffer", out SceneLightingUniformBufferHandle );
-		GL.BindBuffer( BufferTarget.UniformBuffer, SceneLightingUniformBufferHandle );
-		var scenelightingbuffersize = 0;
-		scenelightingbuffersize += Marshal.SizeOf( typeof( OpenTKMath.Vector4 ) );
-		scenelightingbuffersize += sizeof( int ) * 4;
-		scenelightingbuffersize += Marshal.SizeOf( typeof( SceneLightManager.PointLight ) ) * SceneLightManager.MaxPointLights;
-		scenelightingbuffersize += Marshal.SizeOf( typeof( SceneLightManager.SpotLight ) ) * SceneLightManager.MaxSpotLights;
-		scenelightingbuffersize += Marshal.SizeOf( typeof( SceneLightManager.DirLight ) ) * SceneLightManager.MaxDirLights;
-		scenelightingbuffersize = scenelightingbuffersize.RoundUpToMultipleOf( 16 );
-		GL.BufferData( BufferTarget.UniformBuffer, scenelightingbuffersize, IntPtr.Zero, BufferUsageHint.StaticDraw );
-		GL.BindBuffer( BufferTarget.UniformBuffer, 1 );
-		GL.BindBufferRange( BufferRangeTarget.UniformBuffer, 1, SceneLightingUniformBufferHandle, IntPtr.Zero, scenelightingbuffersize );
 	}
 
 	public void UpdateSceneUniformBuffer()
@@ -49,100 +28,44 @@ public class UniformBufferManager
 			buffer.Set( "g_flGamma", DebugOverlay.Gamma );
 			buffer.Update();
 		}
-		//// update per view uniform buffer
-		//GL.BindBuffer( BufferTarget.UniformBuffer, SceneUniformBufferHandle );
-		//// prepare data
-		//var sceneuniformbuffer = new SceneUniformBuffer
-		//{
-		//	g_matWorldToProjection = Camera.ActiveCamera?.ProjectionMatrix ?? OpenTKMath.Matrix4.CreatePerspectiveFieldOfView( 0, 0, 0, 0 ),
-		//	g_matWorldToView = Camera.ActiveCamera?.ViewMatrix ?? OpenTKMath.Matrix4.LookAt( new Vector3(), new Vector3(), new Vector3() ),
-		//	g_vCameraPositionWs = Camera.ActiveCamera?.Position ?? new Vector3(),
-		//	g_vCameraDirWs = Camera.ActiveCamera?.Rotation.Forward ?? new Vector3(),
-		//	g_vCameraUpDirWs = Camera.ActiveCamera?.Rotation.Up ?? new Vector3(),
-		//	g_flTime = Time.Now,
-		//	g_flNearPlane = Camera.ActiveCamera?.ZNear ?? 0.0f,
-		//	g_flFarPlane = Camera.ActiveCamera?.ZFar ?? 0.0f,
-		//	g_vViewportSize = Screen.Size,
-		//	g_flGamma = DebugOverlay.Gamma
-		//};
-		//// put data in buffer
-		//GL.BufferData( BufferTarget.UniformBuffer, Marshal.SizeOf( sceneuniformbuffer ).RoundUpToMultipleOf( 16 ), ref sceneuniformbuffer, BufferUsageHint.StaticDraw );
 	}
 
 	public void UpdateAmbientLightColor( Color col )
 	{
-		// update light uniform buffer
-		GL.BindBuffer( BufferTarget.UniformBuffer, SceneLightingUniformBufferHandle );
-
-		GL.BufferSubData( BufferTarget.UniformBuffer, IntPtr.Zero, Marshal.SizeOf( typeof( OpenTKMath.Vector4 ) ), ref col );
+		if ( UniformBuffer.All.TryGetValue( "SceneLightingUniformBuffer", out var buffer ) )
+		{
+			buffer.Set( "g_vAmbientLightingColor", col );
+			buffer.Update();
+		}
 	}
 
 	public void UpdatePointlights( SceneLightManager.PointLight[] lights, int num )
 	{
-		// update light uniform buffer
-		GL.BindBuffer( BufferTarget.UniformBuffer, SceneLightingUniformBufferHandle );
-
-		// point lights num
-		GL.BufferSubData( BufferTarget.UniformBuffer, (IntPtr)Marshal.SizeOf( typeof( OpenTKMath.Vector4 ) ), sizeof( int ), ref num );
-		// light array data
-		GL.BufferSubData( BufferTarget.UniformBuffer, (IntPtr)(Marshal.SizeOf( typeof( OpenTKMath.Vector4 ) ) + sizeof( int ) * 4), Marshal.SizeOf( typeof( SceneLightManager.PointLight ) ) * SceneLightManager.MaxPointLights, lights );
+		if ( UniformBuffer.All.TryGetValue( "SceneLightingUniformBuffer", out var buffer ) )
+		{
+			buffer.Set( "g_nNumPointlights", num );
+			buffer.Set( "g_PointLights", lights );
+			buffer.Update();
+		}
 	}
 
 	public void UpdateSpotlights( SceneLightManager.SpotLight[] lights, int num )
 	{
-		// update light uniform buffer
-		GL.BindBuffer( BufferTarget.UniformBuffer, SceneLightingUniformBufferHandle );
-
-		// spot lights num
-		GL.BufferSubData( BufferTarget.UniformBuffer, (IntPtr)Marshal.SizeOf( typeof( OpenTKMath.Vector4 ) ) + sizeof( int ), sizeof( int ), ref num );
-
-		var offset = 0;
-		offset += Marshal.SizeOf( typeof( OpenTKMath.Vector4 ) );
-		offset += sizeof( int ) * 4; // number of lights (+ pad)
-		offset += Marshal.SizeOf( typeof( SceneLightManager.PointLight ) ) * SceneLightManager.MaxPointLights;
-		var size = Marshal.SizeOf( typeof( SceneLightManager.SpotLight ) ) * SceneLightManager.MaxSpotLights;
-		// lights array data
-		GL.BufferSubData( BufferTarget.UniformBuffer, (IntPtr)offset, size, lights );
+		if ( UniformBuffer.All.TryGetValue( "SceneLightingUniformBuffer", out var buffer ) )
+		{
+			buffer.Set( "g_nNumSpotlights", num );
+			buffer.Set( "g_SpotLights", lights );
+			buffer.Update();
+		}
 	}
 
 	public void UpdateDirlights( SceneLightManager.DirLight[] lights, int num )
 	{
-		// update light uniform buffer
-		GL.BindBuffer( BufferTarget.UniformBuffer, SceneLightingUniformBufferHandle );
-
-		// dir lights num
-		GL.BufferSubData( BufferTarget.UniformBuffer, (IntPtr)Marshal.SizeOf( typeof( OpenTKMath.Vector4 ) ) + sizeof( int ) * 2, sizeof( int ), ref num );
-
-		var offset = 0;
-		offset += Marshal.SizeOf( typeof( OpenTKMath.Vector4 ) );
-		offset += sizeof( int ) * 4; // number of lights (+ pad)
-		offset += Marshal.SizeOf( typeof( SceneLightManager.PointLight ) ) * SceneLightManager.MaxPointLights;
-		offset += Marshal.SizeOf( typeof( SceneLightManager.SpotLight ) ) * SceneLightManager.MaxSpotLights;
-		var size = Marshal.SizeOf( typeof( SceneLightManager.DirLight ) ) * SceneLightManager.MaxDirLights;
-		// lights array data
-		GL.BufferSubData( BufferTarget.UniformBuffer, (IntPtr)offset, size, lights );
-	}
-
-	public struct SceneUniformBuffer
-	{
-		public OpenTKMath.Matrix4 g_matWorldToProjection;  // 16	(col0)
-														   // 16	(col1)
-														   // 16	(col2)
-														   // 16	(col3)
-		public OpenTKMath.Matrix4 g_matWorldToView;        // 16	(col0)
-														   // 16	(col1)
-														   // 16	(col2)
-														   // 16	(col3)
-		public Vector3 g_vCameraPositionWs;     // 12	
-		public float pad1;                      // 4	(padding)
-		public Vector3 g_vCameraDirWs;          // 12
-		public float pad2;                      // 4	(padding)
-		public Vector3 g_vCameraUpDirWs;        // 12
-		public float pad3;                      // 4	(padding)
-		public OpenTKMath.Vector2 g_vViewportSize;         // 8
-		public float g_flTime;                  // 4
-		public float g_flNearPlane;             // 4
-		public float g_flFarPlane;              // 4
-		public float g_flGamma;                 // 4
+		if ( UniformBuffer.All.TryGetValue( "SceneLightingUniformBuffer", out var buffer ) )
+		{
+			buffer.Set( "g_nNumDirlights", num );
+			buffer.Set( "g_DirLights", lights );
+			buffer.Update();
+		}
 	}
 }

--- a/Renderer/scene/SceneLightManager.cs
+++ b/Renderer/scene/SceneLightManager.cs
@@ -1,4 +1,6 @@
-﻿namespace Vanadium.Renderer.Scene;
+﻿using Vanadium.Renderer.RenderData.Buffers;
+
+namespace Vanadium.Renderer.Scene;
 
 public class SceneLightManager
 {

--- a/Window.cs
+++ b/Window.cs
@@ -55,6 +55,22 @@ public class Window : GameWindow
 		// setup uniform buffers
 		UniformBufferManager.Init();
 
+		UniformBuffer.DeclareBuffer( "SceneUniformBuffer" )
+			.AddField<OpenTKMath.Matrix4>( "g_matWorldToProjection" )
+			.AddField<OpenTKMath.Matrix4>( "g_matWorldToView" )
+
+			.AddField<Vector3>( "g_vCameraPositionWs", 4 )
+			.AddField<Vector3>( "g_vCameraDirWs", 4 )
+			.AddField<Vector3>( "g_vCameraUpDirWs", 4 )
+
+			.AddField<OpenTKMath.Vector2i>( "g_vViewportSize" )
+
+			.AddField<float>( "g_flTime" )
+			.AddField<float>( "g_flNearPlane" )
+			.AddField<float>( "g_flFarPlane" )
+			.AddField<float>( "g_flGamma" )
+			.Build();
+
 		SceneLight.SetAmbientLightColor( new Color( 36.0f / 255.0f, 60.0f / 255.0f, 102.0f / 255.0f ) );
 
 		// init debug line buffers

--- a/Window.cs
+++ b/Window.cs
@@ -50,41 +50,31 @@ public class Window : GameWindow
 
 		GL.Enable( EnableCap.TextureCubeMapSeamless );
 
+		Log.Info( "---===Initializing Main Scene World===---" );
 		_ = new SceneWorld( "Main SceneWorld" );
 
-		// setup uniform buffers
-		UniformBufferManager.Init();
-
-		UniformBuffer.DeclareBuffer( "SceneUniformBuffer" )
-			.AddField<OpenTKMath.Matrix4>( "g_matWorldToProjection" )
-			.AddField<OpenTKMath.Matrix4>( "g_matWorldToView" )
-
-			.AddField<Vector3>( "g_vCameraPositionWs", 4 )
-			.AddField<Vector3>( "g_vCameraDirWs", 4 )
-			.AddField<Vector3>( "g_vCameraUpDirWs", 4 )
-
-			.AddField<OpenTKMath.Vector2i>( "g_vViewportSize" )
-
-			.AddField<float>( "g_flTime" )
-			.AddField<float>( "g_flNearPlane" )
-			.AddField<float>( "g_flFarPlane" )
-			.AddField<float>( "g_flGamma" )
-			.Build();
+		// setup core uniform buffers
+		Log.Info( "\n---===Initializing Uniform Buffers===---" );
+		UniformBuffer.InitCore();
 
 		SceneLight.SetAmbientLightColor( new Color( 36.0f / 255.0f, 60.0f / 255.0f, 102.0f / 255.0f ) );
 
 		// init debug line buffers
+		Log.Info( "\n---===Initializing Debug Draw===---" );
 		DebugDraw.Init();
 
 		// init ui
 		_guicontroller = new ImGuiController( ClientSize );
 
 		// precache error model
+		Log.Info( "\n---===Precaching Error Model===---" );
 		Model.Precache( Model.Error );
 
 		// set skybox
+		Log.Info( "\n---===Initializing Skybox===---" );
 		Skybox.Load( "materials/skybox/skybox01_hdr.vanmat" );
 
+		Log.Info( "\n---===Initializing Floor===---" );
 		var floor = new SceneObject
 		{
 			Model = Model.Load( "models/brickwall.fbx" ),
@@ -93,6 +83,7 @@ public class Window : GameWindow
 		};
 		floor.SetMaterialOverride( "materials/pbrtest/tiles.vanmat" );
 
+		Log.Info( "\n---===Initializing Axis===---" );
 		_ = new SceneObject
 		{
 			Model = Model.Primitives.Axis
@@ -109,6 +100,8 @@ public class Window : GameWindow
 		Log.Debug( $"Load took: {Timer.ElapsedMilliseconds}ms" );
 
 		Timer.Restart();
+
+		Log.Info( "---===Initialization done===---" );
 	}
 
 	protected override void OnRenderFrame( FrameEventArgs e )

--- a/Window.cs
+++ b/Window.cs
@@ -3,6 +3,7 @@ using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Desktop;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 using System.Runtime.InteropServices;
+using Vanadium.Renderer.RenderData.Buffers;
 
 namespace Vanadium;
 


### PR DESCRIPTION
This PR introduces an abstraction for the declaration and population of uniform buffer data. This system could potentially be adapted to other types of buffers as well, but is only supposed to replace the old UniformBuffer management for now.

Examples for the two core uniform buffers can be found in UniformBuffer.cs